### PR TITLE
Bumped swift and swiftlint versions to current

### DIFF
--- a/versions/0.46.5/Dockerfile
+++ b/versions/0.46.5/Dockerfile
@@ -2,8 +2,8 @@ FROM cimg/base:2020.05
 
 LABEL maintainer="BytesGuy <bytesguy@users.noreply.github.com>"
 
-ENV SWIFTLINT_VERSION 0.39.2
-ENV SWIFT_VERSION 5.2.3
+ENV SWIFTLINT_VERSION 0.46.5
+ENV SWIFT_VERSION 5.6.1
 
 USER root
 


### PR DESCRIPTION
I bumped the swift version and swiftlint version. It was really easy thanks to your previous work.

We've been using your swiftlint docker image for some time now. Recently however it began to fail for us. This version bump fixed up our build.
